### PR TITLE
Include overflow-x and overflow-y. closes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,8 @@ config.rules['declaration-block-properties-order'] = [[
   'min-height',
   'max-height',
   'overflow',
+  'overflow-x',
+  'overflow-y',
   'list-style',
   'caption-side',
   'table-layout',


### PR DESCRIPTION
Added missing overflow properties into the mix.